### PR TITLE
Update aleppo compile

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,8 +17,9 @@ defmodule Quaff.Mixfile do
         deps(:prod) ]
   end
   defp deps(_) do
-    [ { :aleppo, compile: "rebar compile",
-        git: "https://github.com/ChicagoBoss/aleppo.git", branch: "master" },
+    [ { :aleppo,
+        git: "https://github.com/ChicagoBoss/aleppo.git", branch: "master",
+        tag: "v0.8.14"},
     ]
   end
 end


### PR DESCRIPTION
Using elixir/mix 1.1.0, mix knows the right thing to do with aleppo.  The way it was before would fail if the user didn't have rebar installed in their path.